### PR TITLE
add more exports

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -4,6 +4,7 @@
   (:use #:cl)
   (:export KENZO-VERSION
 	   *CMBN-CONTROL*
+           *LIST-LIST*
 
 	   ;; chain-complexes.lisp
 
@@ -102,6 +103,7 @@
 	   ;; special-smsts.lisp
 
 	   SPHERE
+	   BUILD-FINITE-SS
 
 	   ;; various.lisp
 


### PR DESCRIPTION
This is needed for extending Kenzo by advanced users. E.g. to be able to use persistent homology code from http://www.unirioja.es/cu/anromero/persistent-homology.zip
(check out https://github.com/dimpase/pershom for the port to your port)